### PR TITLE
Fix widening during org-alert-check

### DIFF
--- a/org-alert.el
+++ b/org-alert.el
@@ -107,9 +107,11 @@
   "Check for active, due deadlines and initiate notifications."
   (interactive)
   (org-alert--preserve-agenda-buffer)
-  (let ((active (org-alert--filter-active (org-alert--get-headlines))))
-    (dolist (dl (org-alert--strip-states active))
-      (alert dl :title org-alert-notification-title)))
+  (save-excursion
+    (save-restriction
+      (let ((active (org-alert--filter-active (org-alert--get-headlines))))
+	(dolist (dl (org-alert--strip-states active))
+	  (alert dl :title org-alert-notification-title)))))
   (org-alert--restore-agenda-buffer))
 
 


### PR DESCRIPTION
Fix #9 

https://www.gnu.org/software/emacs/manual/html_node/eintr/save_002drestriction.html
Documentation said to use save-excursion and  save-restriction in function for saving current narrowing.