### PR TITLE
Avoid disrupting minibuffer.

### DIFF
--- a/org-alert.el
+++ b/org-alert.el
@@ -106,13 +106,14 @@
 (defun org-alert-check ()
   "Check for active, due deadlines and initiate notifications."
   (interactive)
-  (org-alert--preserve-agenda-buffer)
-  (save-excursion
-    (save-restriction
-      (let ((active (org-alert--filter-active (org-alert--get-headlines))))
-	(dolist (dl (org-alert--strip-states active))
-	  (alert dl :title org-alert-notification-title)))))
-  (org-alert--restore-agenda-buffer))
+  (unless (minibufferp)
+    (org-alert--preserve-agenda-buffer)
+    (save-excursion
+      (save-restriction
+	(let ((active (org-alert--filter-active (org-alert--get-headlines))))
+	  (dolist (dl (org-alert--strip-states active))
+	    (alert dl :title org-alert-notification-title)))))
+    (org-alert--restore-agenda-buffer)))
 
 
 (defun org-alert-enable ()


### PR DESCRIPTION
* org-alert.el (org-alert-check): Don't do anything if inside
  minibuffer. Just skip one roundtrip.
I think this solve issue #13 by the way.