### PR TITLE
Rework usage of `org-agenda-list' to avoid messing up windows.

### DIFF
--- a/org-alert.el
+++ b/org-alert.el
@@ -63,13 +63,12 @@
 
 (defun org-alert--get-headlines ()
   "Return the current org agenda as text only."
-  (let (org-agenda-buffer-tmp-name org-agenda-buffer-name)
-    (with-temp-buffer
-      (let ((org-agenda-sticky nil)
-	    (org-agenda-buffer-tmp-name (buffer-name)))
-	(org-agenda-list 1)
-	(org-alert--unique-headlines org-alert-headline-regexp
-				     (buffer-substring-no-properties (point-min) (point-max)))))))
+  (with-temp-buffer
+    (let ((org-agenda-sticky nil)
+	  (org-agenda-buffer-tmp-name (buffer-name)))
+      (ignore-errors (org-agenda-list 1))
+      (org-alert--unique-headlines org-alert-headline-regexp
+				   (buffer-substring-no-properties (point-min) (point-max))))))
 
 
 (defun org-alert--headline-complete? (headline)

--- a/org-alert.el
+++ b/org-alert.el
@@ -65,7 +65,8 @@
   "Return the current org agenda as text only."
   (let (org-agenda-buffer-tmp-name org-agenda-buffer-name)
     (with-temp-buffer
-      (let ((org-agenda-buffer-tmp-name (current-buffer)))
+      (let ((org-agenda-sticky nil)
+	    (org-agenda-buffer-tmp-name (current-buffer)))
 	(org-agenda-list 1)
 	(org-alert--unique-headlines org-alert-headline-regexp
 				     (buffer-substring-no-properties (point-min) (point-max)))))))
@@ -95,7 +96,11 @@
       (save-restriction
 	(let ((active (org-alert--filter-active (org-alert--get-headlines))))
 	  (dolist (dl (org-alert--strip-states active))
-	    (alert dl :title org-alert-notification-title)))))))
+	    (alert dl :title org-alert-notification-title)))))
+    (when (get-buffer org-agenda-buffer-name)
+      (ignore-errors
+    	(with-current-buffer org-agenda-buffer-name
+    	  (org-agenda-redo t))))))
 
 
 (defun org-alert-enable ()

--- a/org-alert.el
+++ b/org-alert.el
@@ -66,7 +66,7 @@
   (let (org-agenda-buffer-tmp-name org-agenda-buffer-name)
     (with-temp-buffer
       (let ((org-agenda-sticky nil)
-	    (org-agenda-buffer-tmp-name (current-buffer)))
+	    (org-agenda-buffer-tmp-name (buffer-name)))
 	(org-agenda-list 1)
 	(org-alert--unique-headlines org-alert-headline-regexp
 				     (buffer-substring-no-properties (point-min) (point-max)))))))


### PR DESCRIPTION
* org-alert.el: review package-requires and keywords to pacify `package-lint`.
  (org-alert--preserve-agenda-buffer,  org-alert--preserve-agenda-buffer): delete unused functions.
  (org-alert--get-headlines): rework to use `with-temp-buffer`.
  (org-alert-check): don't trigger if inside minibuffer.

This should solve issues #13 and #14.