### PR TITLE
Allow for events without times

### DIFF
--- a/org-alert.el
+++ b/org-alert.el
@@ -96,8 +96,10 @@ heading and the scheduled/deadline time"
   (let* ((entry (org-alert--parse-entry))
 	 (head (car entry))
 	 (time (cadr entry)))
-    (when (org-alert--check-time time)
-      (alert (concat time ": " head) :title org-alert-notification-title))))
+    (if time
+        (when (org-alert--check-time time)
+          (alert (concat time ": " head) :title org-alert-notification-title))
+        (alert head :title org-alert-notification-title))))
 
 (defun org-alert-check ()
   "Check for active, due deadlines and initiate notifications."


### PR DESCRIPTION
7f49fc665ce8becf9543032e9290acd6d53ca0c2 introduced changes which check for event times in order to control when notifications are sent. This caused problems for events with a date only as the time would be `nil`.

Add conditional logic so that time is only considered if it exists for an event.