### PR TITLE
Add alert category

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ variable. Use this if you'd like to customize the display of org
 notifications when using a daemon such as
 [dunst](https://github.com/knopwob/dunst).
 
+### Custom categories
+
+org-alert uses the category `'org-alert` by default. You can set this to
+something else by changing the `org-alert-notification-category`
+variable. Use this if you'd like to customize the display of org
+notifications when using a notification function that supports
+distinct categories via the `alert` `:category` property.
+
 ### Custom regexp for searching agenda entries
 
 org-alert searches for agenda entries with 'Sched' or 'Deadline' word

--- a/org-alert.el
+++ b/org-alert.el
@@ -67,7 +67,7 @@ is used to extract the time")
   "REMINDERN"
   "org property used to set a custom cutoff for an individual entry")
 
-(defvar org-alert-category
+(defvar org-alert-notification-category
   'org-alert
   "The symbol to pass to alert as the :category property, in order
 to allow differentiation from other uses of alert")
@@ -158,9 +158,9 @@ heading, the scheduled/deadline time, and the cutoff to apply"
 	    (when (org-alert--check-time time cutoff)
 	      (alert (concat time ": " head)
                      :title org-alert-notification-title
-                     :category org-alert-category))
+                     :category org-alert-notification-category))
 	  (alert head :title org-alert-notification-title
-                 :category org-alert-category))))))
+                 :category org-alert-notification-category))))))
 
 (defun org-alert-check ()
   "Check for active, due deadlines and initiate notifications."

--- a/org-alert.el
+++ b/org-alert.el
@@ -67,6 +67,11 @@ is used to extract the time")
   "REMINDERN"
   "org property used to set a custom cutoff for an individual entry")
 
+(defvar org-alert-category
+  'org-alert
+  "The symbol to pass to alert as the :category property, in order
+to allow differentiation from other uses of alert")
+
 (defun org-alert--read-subtree ()
   "Return the current subtree as a string. Adapted from
 `org-copy-subtree` from org-mode."
@@ -151,8 +156,11 @@ heading, the scheduled/deadline time, and the cutoff to apply"
       (cl-destructuring-bind (head time cutoff) entry
 	(if time
 	    (when (org-alert--check-time time cutoff)
-	      (alert (concat time ": " head) :title org-alert-notification-title))
-	  (alert head :title org-alert-notification-title))))))
+	      (alert (concat time ": " head)
+                     :title org-alert-notification-title
+                     :category org-alert-category))
+	  (alert head :title org-alert-notification-title
+                 :category org-alert-category))))))
 
 (defun org-alert-check ()
   "Check for active, due deadlines and initiate notifications."


### PR DESCRIPTION
Added support for passing `:category` to `alert`, so that alert notification functions that support different categories can distinguish alerts from `org-alert`

Adds a new variable `org-alert-notification-category`, which defaults to `'org-alert`.

Updated `README` to describe the new variable