### PR TITLE
Use org-ql to match org headings to be alerted.

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-emacs -batch -f package-initialize \
+emacs -Q -batch -f package-initialize \
 	  --eval '(add-to-list (quote package-archives) (quote ("melpa" . "http://melpa.org/packages/")))' \
 	  --eval '(use-package alert :ensure t)' \
 	  --eval '(use-package org-ql :ensure t)' \

--- a/ci.sh
+++ b/ci.sh
@@ -4,6 +4,8 @@ set -xe
 
 emacs -batch -f package-initialize \
 	  --eval '(add-to-list (quote package-archives) (quote ("melpa" . "http://melpa.org/packages/")))' \
-	  --eval '(use-package alert :ensure t)'
+	  --eval '(use-package alert :ensure t)' \
+	  --eval '(use-package org-ql :ensure t)' \
+	  --eval '(use-package ts :ensure t)'
 
 cd test && make test

--- a/org-alert.el
+++ b/org-alert.el
@@ -4,7 +4,7 @@
 
 ;; Author: Stephen Pegoraro <spegoraro@tutive.com>
 ;; Version: 0.2.0
-;; Package-Requires: ((org "9.0") (alert "1.2") (org-ql "0.8.7") (ts "0.2-pre"))
+;; Package-Requires: ((org "9.0") (alert "1.2") (org-ql "0.9-pre") (ts "0.2-pre"))
 ;; Keywords: org, org-mode, notify, notifications, calendar
 ;; URL: https://github.com/spegoraro/org-alert
 

--- a/org-alert.el
+++ b/org-alert.el
@@ -201,14 +201,15 @@ heading, the scheduled/deadline time, and the cutoff to apply"
 This will match org heading with active timestamp, from now, until the
 next `org-alert-notify-cutoff' minutes."
   (interactive)
-  (org-ql-select (org-agenda-files)
-	`(or (ts-active :with-time t
-					:from ,(org-alert--get-after-event-cutoff-time)
-					:to ,(ts-format "%F %T" (ts-adjust 'minute org-alert-notify-cutoff (ts-now))))
-		 (and (property ,org-alert-cutoff-prop)
-			  (ts-active :with-time t
-						 :from ,(org-alert--get-after-event-cutoff-time))))
-	:action #'org-alert--dispatch)
+  (let ((org-ql-cache (make-hash-table)))
+    (org-ql-select (org-agenda-files)
+	  `(or (ts-active :with-time t
+					  :from ,(org-alert--get-after-event-cutoff-time)
+					  :to ,(ts-format "%F %T" (ts-adjust 'minute org-alert-notify-cutoff (ts-now))))
+		   (and (property ,org-alert-cutoff-prop)
+			    (ts-active :with-time t
+						   :from ,(org-alert--get-after-event-cutoff-time))))
+	  :action #'org-alert--dispatch))
   t)
 
 ;;;###autoload

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,5 @@
 test:
-	emacs -batch -f package-initialize \
+	emacs -Q -batch -f package-initialize \
           -l ert \
           -l alert \
           -l ../org-alert.el \

--- a/test/test.el
+++ b/test/test.el
@@ -66,7 +66,9 @@ a post-event cutoff set."
 a post-event cutoff set but the current time set appropriately."
   (with-test-org nil
     (with-current-time (25704 52667 0 0) ; 9:40:11
-      (let ((org-alert-notify-after-event-cutoff 60))
+      (let (
+            ;; (org-alert-notify-after-event-cutoff 60)
+            )
         (should (= (length test-alert-notifications) 0))
         (org-alert-check)
         (should (= (length test-alert-notifications) 1))))))
@@ -78,7 +80,9 @@ a post-event cutoff set but the current time set appropriately."
     ;; (current-time-string '(25704 52655 0 0)) => "Sat May 20 09:39:59 2023" or
     ;; just before the notification should trigger
     (with-current-time (25704 52655 0 0)
-      (let ((org-alert-notify-after-event-cutoff 60))
+      (let (
+            ;; (org-alert-notify-after-event-cutoff 60)
+            )
         (org-alert-check)
         (should (= (length test-alert-notifications) 0))))))
 

--- a/test/test.el
+++ b/test/test.el
@@ -88,6 +88,14 @@ a post-event cutoff set but the current time set appropriately."
       (org-alert-check)
       (should (= (length test-alert-notifications) 1)))))
 
+(ert-deftest check-alert-multiple ()
+  (with-test-org "plain.org"
+    (with-current-time (25704 52957 0 0) ; 9:45:01
+      (org-alert-check)
+      (org-alert-check)
+      (org-alert-check)
+      (should (= (length test-alert-notifications) 3)))))
+
 (ert-deftest check-alert-none ()
   (with-test-org "plain.org"
     (with-current-time (25704 52945 0 0) ; 9:44:49


### PR DESCRIPTION
Hi! I've implemented a way to fetch only the related headings for alerting.

I kind of cheat a little using `org-ql`, but I think it worked out pretty well.

It should fix #27, though I'm not sure if I have handled all use cases.

I try to implement it in a way that's backward compatible, so some customization might not be in place right now.

We could also potentially make the `org-alert-check` customizable too, but I've put this off for now since I think the current implementation is good enough.

To use this new feature, we need to add:

``` emacs-lisp
;; or setopt for fancier option :)
(setq org-alert-match-string 'org-ql
      ;; use non-greedy regex to match the `from' time.
      org-alert-time-match-string "\\(?:SCHEDULED\\|DEADLINE\\):.*?<.*?\\([0-9]\\{2\\}:[0-9]\\{2\\}\\).*>")
```